### PR TITLE
metaparameters are renamed better, less verbose

### DIFF
--- a/Libraries/JUCE/modules/jura_framework/control/jura_MetaParameter.cpp
+++ b/Libraries/JUCE/modules/jura_framework/control/jura_MetaParameter.cpp
@@ -229,9 +229,22 @@ void MetaParameterManager::updateMetaName(int index)
 {
   if(autoUpdateMetaNames && index >= 0 && index < size(metaParams))
   {
-    String name = "Meta " + String(index);
-    for(int i = 0; i < size(metaParams[index]->params); i++)
-      name += ", " + metaParams[index]->params[i]->getName();
-    setMetaName(index, name);
+    auto sz = size(metaParams[index]->params);
+    auto idxStr = String(index);
+    if (sz > 0)
+    {
+      String name = idxStr+": ";
+
+      for (auto i = 0; i < sz; i++)
+        name += metaParams[index]->params[i]->getName()+", ";
+
+      name = name.substring(0, name.length()-2);
+
+      setMetaName(index, name);
+    }
+    else
+    {
+      setMetaName(index, "Meta "+idxStr);
+    }      
   }
 }

--- a/Libraries/JUCE/modules/jura_framework/gui/widgets/jura_AutomatableWidget.cpp
+++ b/Libraries/JUCE/modules/jura_framework/gui/widgets/jura_AutomatableWidget.cpp
@@ -450,7 +450,7 @@ void AutomatableWidget::addPopUpMetaItems()
     int mi = mcp->getMetaParameterIndex();
     String miString;
     if(mi > -1)
-      miString = "(currently " + String(mi) + ": " + mcp->getMetaParameterName() + ")";
+      miString = "(currently " + mcp->getMetaParameterName() + ")";
     else
       miString = "(currently none)";
 


### PR DESCRIPTION
`Meta 1` in host becomes `1: <parameter name>` after rename

`currently 1: Meta 1 <parameter name>` is now `currently 1: <parameter name>` in plugin